### PR TITLE
Do not log or check in headers.

### DIFF
--- a/call_graph.cc
+++ b/call_graph.cc
@@ -63,4 +63,17 @@ void CallGraph::InitializeCallGraph(const CFTable &cf_table,
   CHECK(empty_.empty());
 }
 
+const std::vector<uintptr_t>& CallGraph::GetFunctionCallees(uintptr_t pc) const {
+  CHECK(IsFunctionEntry(pc)) << VV(pc) << " is not a function entry.";
+  const auto it = call_graph_.find(pc);
+  if (it == call_graph_.cend()) return empty_;
+  return it->second;
+}
+const std::vector<uintptr_t>& CallGraph::GetBasicBlockCallees(uintptr_t pc) const {
+  CHECK(basic_blocks_.contains(pc)) << VV(pc) << " is not a basic block.";
+  const auto it = basic_block_callees_.find(pc);
+  if (it == basic_block_callees_.cend()) return empty_;
+  return it->second;
+}
+
 }  // namespace centipede

--- a/call_graph.h
+++ b/call_graph.h
@@ -21,9 +21,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/log/check.h"
 #include "./control_flow.h"
-#include "./logging.h"
 
 namespace centipede {
 
@@ -33,18 +31,10 @@ class CallGraph {
   // section is not available, the hash maps will be empty.
   void InitializeCallGraph(const CFTable& cf_table, const PCTable& pc_table);
 
-  const std::vector<uintptr_t>& GetFunctionCallees(uintptr_t pc) const {
-    CHECK(IsFunctionEntry(pc)) << VV(pc) << " is not a function entry.";
-    const auto it = call_graph_.find(pc);
-    if (it == call_graph_.cend()) return empty_;
-    return it->second;
-  }
-  const std::vector<uintptr_t>& GetBasicBlockCallees(uintptr_t pc) const {
-    CHECK(basic_blocks_.contains(pc)) << VV(pc) << " is not a basic block.";
-    const auto it = basic_block_callees_.find(pc);
-    if (it == basic_block_callees_.cend()) return empty_;
-    return it->second;
-  }
+  const std::vector<uintptr_t>& GetFunctionCallees(uintptr_t pc) const;
+
+  const std::vector<uintptr_t>& GetBasicBlockCallees(uintptr_t pc) const;
+
   const absl::flat_hash_set<uintptr_t>& GetFunctionEntries() const {
     return function_entries_;
   }

--- a/centipede_callbacks.cc
+++ b/centipede_callbacks.cc
@@ -35,6 +35,14 @@
 
 namespace centipede {
 
+CentipedeCallbacks::CentipedeCallbacks(const Environment &env)
+  : env_(env),
+    byte_array_mutator_(env.knobs, GetRandomSeed(env.seed)),
+    inputs_blobseq_(shmem_name1_.c_str(), env.shmem_size_mb << 20),
+    outputs_blobseq_(shmem_name2_.c_str(), env.shmem_size_mb << 20) {
+CHECK(byte_array_mutator_.set_max_len(env.max_len));
+}
+
 void CentipedeCallbacks::PopulateBinaryInfo(BinaryInfo &binary_info) {
   // Running in main thread, create our own temp dir.
   if (!std::filesystem::exists(temp_dir_)) {

--- a/centipede_callbacks.h
+++ b/centipede_callbacks.h
@@ -30,7 +30,6 @@
 #include "./environment.h"
 #include "./execution_result.h"
 #include "./knobs.h"
-#include "./logging.h"
 #include "./shared_memory_blob_sequence.h"
 #include "./symbol_table.h"
 #include "./util.h"
@@ -45,13 +44,7 @@ namespace centipede {
 class CentipedeCallbacks {
  public:
   // `env` is used to pass flags to `this`, it must outlive `this`.
-  CentipedeCallbacks(const Environment &env)
-      : env_(env),
-        byte_array_mutator_(env.knobs, GetRandomSeed(env.seed)),
-        inputs_blobseq_(shmem_name1_.c_str(), env.shmem_size_mb << 20),
-        outputs_blobseq_(shmem_name2_.c_str(), env.shmem_size_mb << 20) {
-    CHECK(byte_array_mutator_.set_max_len(env.max_len));
-  }
+  CentipedeCallbacks(const Environment &env);
   virtual ~CentipedeCallbacks() {}
 
   // Feeds `inputs` into the `binary`, for every input populates `batch_result`.

--- a/control_flow.h
+++ b/control_flow.h
@@ -23,7 +23,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "./defs.h"
-#include "./logging.h"
 
 namespace centipede {
 
@@ -116,11 +115,7 @@ class ControlFlowGraph {
 
   // Returns cyclomatic complexity of function PC. CHECK-fails if it is not a
   // valid function PC.
-  uint32_t GetCyclomaticComplexity(uintptr_t pc) const {
-    auto it = function_complexities_.find(pc);
-    CHECK(it != function_complexities_.end());
-    return it->second;
-  }
+  uint32_t GetCyclomaticComplexity(uintptr_t pc) const;
 
   // Returns true if the given basic block is function entry.
   bool BlockIsFunctionEntry(PCIndex pc_index) const {
@@ -131,11 +126,7 @@ class ControlFlowGraph {
 
   // Returns the idx in pc_table associated with the PC, CHECK-fails if the PC
   // is not in the pc_table.
-  PCIndex GetPcIndex(uintptr_t pc) const {
-    auto it = pc_index_map_.find(pc);
-    CHECK(it != pc_index_map_.end()) << VV(pc) << " is not in pc_table.";
-    return it->second;
-  }
+  PCIndex GetPcIndex(uintptr_t pc) const;
 
   // Returns true if the PC is in PCTable.
   bool IsInPcTable(uintptr_t pc) const { return pc_index_map_.contains(pc); }
@@ -144,14 +135,7 @@ class ControlFlowGraph {
   // reachable from `pc`. The reachability is computed once, lazily.
   // The method is const, under the hood it uses a mutable data member.
   // Thread-safe: can be called concurrently from multiple threads
-  const std::vector<uintptr_t> &LazyGetReachabilityForPc(uintptr_t pc) const {
-    CHECK_EQ(reachability_.size(), pc_index_map_.size());
-    auto pc_index = GetPcIndex(pc);
-    std::call_once(*(reachability_[pc_index].once), [this, &pc, &pc_index]() {
-      reachability_[pc_index].reach = ComputeReachabilityForPc(pc);
-    });
-    return reachability_[pc_index].reach;
-  }
+  const std::vector<uintptr_t> &LazyGetReachabilityForPc(uintptr_t pc) const;
 
  private:
   // Map from PC to the idx in pc_table.


### PR DESCRIPTION
Some environments (Chromium, at least) have alternative implementations of macros such as LOG or CHECK which conflict with the absl equivalents that are used by Centipede.

Remove all such CHECKs, and corresponding header inclusions, from centipede headers that are intended to be included within fuzzers.

This change may not yet be exhaustive but enables Chromium compilation of Centipede to get further.

We are not yet accepting external contributions at this time. Stay tuned.
